### PR TITLE
prevent html tags escape to work w/ auto_html gem in production

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -6,7 +6,7 @@
   <span class="content">
     <%#= without adding migration use: auto_html(post.content) { simple_format; link(:target => 'blank') } %>
     <%# post.content is needed in case content_html is empty %>
-    <%= post.content_html || post.content %>
+    <%= raw(post.content_html) || post.content %>
     <%# the condition prevents an empty image upload if the user chose not to upload
     an image. The `picture?` method is created from CarrierWave based on the picture column attribute
      %>


### PR DESCRIPTION
Heroku automatically escapes HTML tags in production but works fine in development. Using `raw` to prevent Rails from escaping HTML tags.
